### PR TITLE
Combining baked and dynamic shadows nicely (lightmap)

### DIFF
--- a/materialsLibrary/materials/water/babylon.waterMaterial.ts
+++ b/materialsLibrary/materials/water/babylon.waterMaterial.ts
@@ -18,6 +18,8 @@ module BABYLON {
         public BonesPerMesh = 0;
         public INSTANCES = false;
         public SPECULARTERM = false;
+        public LOGARITHMICDEPTH = false;
+
 
         constructor() {
             super();
@@ -106,8 +108,10 @@ module BABYLON {
 
         private _defines = new WaterMaterialDefines();
         private _cachedDefines = new WaterMaterialDefines();
-		
-		/**
+
+        private _useLogarithmicDepth: boolean;
+
+        /**
 		* Constructor
 		*/
 		constructor(name: string, scene: Scene, public renderTargetSize: Vector2 = new Vector2(512, 512)) {
@@ -116,7 +120,16 @@ module BABYLON {
 			// Create render targets
 			this._createRenderTargets(scene, renderTargetSize);
         }
-		
+
+        @serialize()
+        public get useLogarithmicDepth(): boolean {
+            return this._useLogarithmicDepth;
+        }
+
+        public set useLogarithmicDepth(value: boolean) {
+            this._useLogarithmicDepth = value && this.getScene().getEngine().getCaps().fragmentDepthSupported;
+        }
+
         // Get / Set
         public get refractionTexture(): RenderTargetTexture {
             return this._refractionRTT;
@@ -228,6 +241,10 @@ module BABYLON {
                 this._defines.POINTSIZE = true;
             }
 
+            if (this.useLogarithmicDepth) {
+                this._defines.LOGARITHMICDEPTH = true;
+            }
+
             // Fog
             if (scene.fogEnabled && mesh && mesh.applyFog && scene.fogMode !== Scene.FOGMODE_NONE && this.fogEnabled) {
                 this._defines.FOG = true;
@@ -284,6 +301,10 @@ module BABYLON {
                     fallbacks.addFallback(1, "FOG");
                 }
 
+                if (this._defines.LOGARITHMICDEPTH) {
+                    fallbacks.addFallback(0, "LOGARITHMICDEPTH");
+                }
+
                 MaterialHelper.HandleFallbacksForShadows(this._defines, fallbacks, this.maxSimultaneousLights);
              
                 if (this._defines.NUM_BONE_INFLUENCERS > 0) {
@@ -320,6 +341,8 @@ module BABYLON {
                     "vNormalInfos", 
                     "mBones",
                     "vClipPlane", "normalMatrix",
+                    "logarithmicDepthConstant",
+
                     // Water
                     "worldReflectionViewProjection", "windDirection", "waveLength", "time", "windForce",
                     "cameraPosition", "bumpHeight", "waveHeight", "waterColor", "colorBlendFactor", "waveSpeed"
@@ -403,7 +426,10 @@ module BABYLON {
 
             // Fog
             MaterialHelper.BindFogParameters(scene, mesh, this._effect);
-            
+
+            // Log. depth
+            MaterialHelper.BindLogDepth(this._defines, this._effect, scene);
+
             // Water
             if (StandardMaterial.ReflectionTextureEnabled) {
                 this._effect.setTexture("refractionSampler", this._refractionRTT);

--- a/materialsLibrary/materials/water/water.fragment.fx
+++ b/materialsLibrary/materials/water/water.fragment.fx
@@ -1,3 +1,7 @@
+#ifdef LOGARITHMICDEPTH
+#extension GL_EXT_frag_depth : enable
+#endif
+
 precision highp float;
 
 // Constants
@@ -51,6 +55,7 @@ varying vec3 vReflectionMapTexCoord;
 varying vec3 vPosition;
 
 #include<clipPlaneFragmentDeclaration>
+#include<logDepthDeclaration>
 
 // Fog
 #include<fogFragmentDeclaration>
@@ -144,6 +149,7 @@ void main(void) {
 	// Composition
 	vec4 color = vec4(finalDiffuse + finalSpecular, alpha);
 
+#include<logDepthFragment>
 #include<fogFragment>
 	
 	gl_FragColor = color;

--- a/materialsLibrary/materials/water/water.fragment.fx
+++ b/materialsLibrary/materials/water/water.fragment.fx
@@ -74,7 +74,8 @@ void main(void) {
 	float alpha = vDiffuseColor.a;
 
 #ifdef BUMP
-	baseColor = texture2D(normalSampler, vNormalUV);
+    //smaller bumps superimposed (better moving waves, no "conveyor belt" look):
+	baseColor = (texture2D(normalSampler, vNormalUV) + texture2D(normalSampler,vec2(-vNormalUV.y*0.33,vNormalUV.x*0.33)))/2.0;
 	vec3 bumpColor = baseColor.rgb;
 
 #ifdef ALPHATEST
@@ -93,8 +94,9 @@ void main(void) {
 
 	// Bump
 #ifdef NORMAL
-	vec3 normalW = normalize(vNormalW);
+    //reflection angle is also perturbed
 	vec2 perturbation = bumpHeight * (baseColor.rg - 0.5);
+	vec3 normalW = normalize(vNormalW + vec3(perturbation.x*3.0,perturbation.y*3.0,0.0));
 #else
 	vec3 normalW = vec3(1.0, 1.0, 1.0);
 	vec2 perturbation = bumpHeight * (vec2(1.0, 1.0) - 0.5);
@@ -106,17 +108,21 @@ void main(void) {
 	
 	vec2 projectedRefractionTexCoords = clamp(vRefractionMapTexCoord.xy / vRefractionMapTexCoord.z + perturbation, 0.0, 1.0);
 	vec4 refractiveColor = texture2D(refractionSampler, projectedRefractionTexCoords);
-	
+
+    //refraction (sea bed) combined with the water color: TODO: fog-like shallow underwater
+    refractiveColor = colorBlendFactor*waterColor + (1.0-colorBlendFactor)*refractiveColor;
+
 	vec2 projectedReflectionTexCoords = clamp(vReflectionMapTexCoord.xy / vReflectionMapTexCoord.z + perturbation, 0.0, 1.0);
 	vec4 reflectiveColor = texture2D(reflectionSampler, projectedReflectionTexCoords);
 	
 	vec3 upVector = vec3(0.0, 1.0, 0.0);
-	
-	float fresnelTerm = max(dot(eyeVector, upVector), 0.0);
+
+	//physically correct water reflection by look angle
+	float fresnelTerm = min(0.95, pow(max(dot(eyeVector, upVector), 0.0),1.5));
 	
 	vec4 combinedColor = refractiveColor * fresnelTerm + reflectiveColor * (1.0 - fresnelTerm);
 	
-	baseColor = colorBlendFactor * waterColor + (1.0 - colorBlendFactor) * combinedColor;
+	baseColor = combinedColor;
 #endif
 
 	// Lighting
@@ -139,12 +145,13 @@ void main(void) {
 #endif
 
 #ifdef SPECULARTERM
-	vec3 finalSpecular = specularBase * specularColor;
+    //specular glare: more concentrated (no flat surface, specular is only for hard lights)
+	vec3 finalSpecular = specularBase * 2.0 * specularColor * specularColor;
 #else
 	vec3 finalSpecular = vec3(0.0);
 #endif
 
-	vec3 finalDiffuse = clamp(diffuseBase * diffuseColor, 0.0, 1.0) * baseColor.rgb;
+	vec3 finalDiffuse = clamp(baseColor.rgb, 0.0, 1.0);
 
 	// Composition
 	vec4 color = vec4(finalDiffuse + finalSpecular, alpha);

--- a/materialsLibrary/materials/water/water.vertex.fx
+++ b/materialsLibrary/materials/water/water.vertex.fx
@@ -48,6 +48,8 @@ varying vec4 vColor;
 #include<fogVertexDeclaration>
 #include<shadowsVertexDeclaration>[0..maxSimultaneousLights]
 
+#include<logDepthDeclaration>
+
 // Water uniforms
 uniform mat4 worldReflectionViewProjection;
 uniform vec2 windDirection;
@@ -61,6 +63,8 @@ uniform float waveSpeed;
 varying vec3 vPosition;
 varying vec3 vRefractionMapTexCoord;
 varying vec3 vReflectionMapTexCoord;
+
+
 
 void main(void) {
 
@@ -134,4 +138,7 @@ void main(void) {
 	vReflectionMapTexCoord.y = 0.5 * (worldPos.w + worldPos.y);
 	vReflectionMapTexCoord.z = worldPos.w;
 #endif
+
+#include<logDepthVertex>
+
 }

--- a/src/Lights/babylon.light.ts
+++ b/src/Lights/babylon.light.ts
@@ -42,6 +42,12 @@
         @serialize()
         public excludeWithLayerMask = 0;
 
+        @serialize()
+        public lightmapExcluded = false;
+
+        @serialize()
+        public lightmapNoSpecular = false;
+
         // PBR Properties.
         @serialize()
         public radius = 0.00001;

--- a/src/Materials/babylon.materialHelper.ts
+++ b/src/Materials/babylon.materialHelper.ts
@@ -5,6 +5,7 @@
             var needNormals = false;
             var needRebuild = false;
             var needShadows = false;
+            var lightmapExcluded = false;
 
             for (var index = 0; index < scene.lights.length; index++) {
                 var light = scene.lights[index];
@@ -103,6 +104,22 @@
                     }
                 }
 
+                //lightmapExcluded
+                if (defines["LIGHTMAPEXCLUDED" + lightIndex] === undefined) {
+                    needRebuild = true;
+                }
+                defines["LIGHTMAPEXCLUDED" + lightIndex] = light.lightmapExcluded;
+                if (light.lightmapExcluded) {
+                    lightmapExcluded = true;
+                }
+
+                //lightmapNoSpecular
+                if (defines["LIGHTMAPNOSPECULAR" + lightIndex] === undefined) {
+                    needRebuild = true;
+                }
+                defines["LIGHTMAPNOSPECULAR" + lightIndex] = light.lightmapNoSpecular;
+
+
                 lightIndex++;
                 if (lightIndex === maxSimultaneousLights)
                     break;
@@ -115,6 +132,13 @@
                 }
 
                 defines["SHADOWFULLFLOAT"] = true;
+            }
+
+            if (defines["LIGHTMAPEXCLUDED"] === undefined) {
+                needRebuild = true;
+            }
+            if (lightmapExcluded) {
+                defines["LIGHTMAPEXCLUDED"] = true;
             }
 
             if (needRebuild) {

--- a/src/Shaders/ShadersInclude/lightFragment.fx
+++ b/src/Shaders/ShadersInclude/lightFragment.fx
@@ -1,16 +1,20 @@
 ﻿#ifdef LIGHT{X}
-	#ifndef SPECULARTERM
-		vec3 vLightSpecular{X} = vec3(0.);
-	#endif
-	#ifdef SPOTLIGHT{X}
-		info = computeSpotLighting(viewDirectionW, normalW, vLightData{X}, vLightDirection{X}, vLightDiffuse{X}.rgb, vLightSpecular{X}, vLightDiffuse{X}.a, glossiness);
-	#endif
-	#ifdef HEMILIGHT{X}
-		info = computeHemisphericLighting(viewDirectionW, normalW, vLightData{X}, vLightDiffuse{X}.rgb, vLightSpecular{X}, vLightGround{X}, glossiness);
-	#endif
-	#if defined(POINTLIGHT{X}) || defined(DIRLIGHT{X})
-		info = computeLighting(viewDirectionW, normalW, vLightData{X}, vLightDiffuse{X}.rgb, vLightSpecular{X}, vLightDiffuse{X}.a, glossiness);
-	#endif
+    #if defined(LIGHTMAP) && defined(LIGHTMAPEXCLUDED{X}) && defined(LIGHTMAPNOSPECULAR{X})
+        //No light calculation
+    #else
+        #ifndef SPECULARTERM
+            vec3 vLightSpecular{X} = vec3(0.);
+        #endif
+        #ifdef SPOTLIGHT{X}
+            info = computeSpotLighting(viewDirectionW, normalW, vLightData{X}, vLightDirection{X}, vLightDiffuse{X}.rgb, vLightSpecular{X}, vLightDiffuse{X}.a, glossiness);
+        #endif
+        #ifdef HEMILIGHT{X}
+            info = computeHemisphericLighting(viewDirectionW, normalW, vLightData{X}, vLightDiffuse{X}.rgb, vLightSpecular{X}, vLightGround{X}, glossiness);
+        #endif
+        #if defined(POINTLIGHT{X}) || defined(DIRLIGHT{X})
+            info = computeLighting(viewDirectionW, normalW, vLightData{X}, vLightDiffuse{X}.rgb, vLightSpecular{X}, vLightDiffuse{X}.a, glossiness);
+        #endif
+    #endif
 	#ifdef SHADOW{X}
 		#ifdef SHADOWVSM{X}
 			shadow = computeShadowWithVSM(vPositionFromLight{X}, shadowSampler{X}, shadowsInfo{X}.z, shadowsInfo{X}.x);
@@ -32,8 +36,17 @@
 	#else
 		shadow = 1.;
 	#endif
-		diffuseBase += info.diffuse * shadow;
-	#ifdef SPECULARTERM
-		specularBase += info.specular * shadow;
+    #if defined(LIGHTMAP) && defined(LIGHTMAPEXCLUDED{X})
+	    diffuseBase += lightmapColor * shadow;
+	    #ifdef SPECULARTERM
+            #ifndef LIGHTMAPNOSPECULAR{X}
+                specularBase += info.specular * shadow * lightmapColor;
+            #endif
+        #endif
+    #else
+	    diffuseBase += info.diffuse * shadow;
+	    #ifdef SPECULARTERM
+		    specularBase += info.specular * shadow;
+	    #endif
 	#endif
 #endif

--- a/src/Shaders/default.fragment.fx
+++ b/src/Shaders/default.fragment.fx
@@ -232,6 +232,10 @@ void main(void) {
 #endif
 	float shadow = 1.;
 
+#ifdef LIGHTMAP
+	vec3 lightmapColor = texture2D(lightmapSampler, vLightmapUV).rgb * vLightmapInfos.y;
+#endif
+
 #include<lightFragment>[0..maxSimultaneousLights]
 
 	// Refraction
@@ -387,14 +391,15 @@ void main(void) {
 	vec4 color = vec4(finalDiffuse * baseAmbientColor + finalSpecular + reflectionColor + refractionColor, alpha);
 #endif
 
+//Old lightmap calculation method
 #ifdef LIGHTMAP
-	vec3 lightmapColor = texture2D(lightmapSampler, vLightmapUV).rgb * vLightmapInfos.y;
-
-#ifdef USELIGHTMAPASSHADOWMAP
-	color.rgb *= lightmapColor;
-#else
-	color.rgb += lightmapColor;
-#endif
+    #ifndef LIGHTMAPEXCLUDED
+        #ifdef USELIGHTMAPASSHADOWMAP
+            color.rgb *= lightmapColor;
+        #else
+            color.rgb += lightmapColor;
+        #endif
+    #endif
 #endif
 
 #include<logDepthFragment>


### PR DESCRIPTION
https://www.bitofgold.com/lightmaptest/
A little demonstration to show what is wrong with the previous ligthmap calculation - no ambient lighting, no other light, no specular highlights.

Does not break the previous lightmap calculation.

material.lightmapTexture needs to be set to activate light map.

light.lightmapExcluded
if true, gets de diffuse lighting from the light map. adds specular highlights mixed widh baked and dynamic shadows.

if false, lightmap calculation is not affected. ("Old" lightmap, material.useLightmapAsShadowmap works as before (simply multiplying color.rgb after composition). Does not look right.)

light.lightmapNoSpecular
if true, does not even calculate the light functions, only the baked lightmap + dynamic shadow. (no specular then from this light, only the baked diffuse)